### PR TITLE
feat: SpanSerde

### DIFF
--- a/corelib/src/serde.cairo
+++ b/corelib/src/serde.cairo
@@ -110,6 +110,26 @@ impl ArraySerde<T, impl TSerde: Serde<T>, impl TDrop: Drop<T>> of Serde<Array<T>
     }
 }
 
+impl SpanSerde<T, impl TSerde: Serde<T>, impl TDrop: Drop<T>> of Serde<Span<T>> {
+    fn serialize(self: @Span<T>, ref output: Array<felt252>) {
+        (*self).len().serialize(ref output);
+        serialize_array_helper(*self, ref output)
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<Span<T>> {
+        let length = *serialized.pop_front()?;
+        let mut arr = ArrayTrait::new();
+        match deserialize_array_helper(ref serialized, arr, length) {
+            Option::Some(arr) => {
+                Option::Some(arr.span())
+            },
+            Option::None(_) => {
+                Option::None(())
+            }
+        }
+    }
+}
+
 fn serialize_array_helper<T, impl TSerde: Serde<T>, impl TDrop: Drop<T>>(
     mut input: Span<T>, ref output: Array<felt252>
 ) {


### PR DESCRIPTION
There's no Serde implementation for Spans. That means we can't for example emit events with Spans - this won't compile:

```rust
#[contract]
mod Foo {
    use array::SpanTrait;

    #[event]
    fn Sup(values: Span<u8>) {}

    #[external]
    fn do_something(s: Span<u8>) {
        Sup(s);
    }
}
```

The error is

```sh
error: Trait has no implementation in context: core::serde::Serde::<core::array::Span::<core::integer::u8>>
 --> contract:21:35
        serde::Serde::<Span<u8>>::serialize(@values, ref __data);
                                  ^*******^

error: Trait has no implementation in context: core::serde::Serde::<core::array::Span::<core::integer::u8>>
 --> contract:53:43
                serde::Serde::<Span<u8>>::deserialize(ref data).expect('Input too short for arguments');
                                          ^*********^

Error: Compilation failed.
```

This PR adds a `SpanSerde` that fixes the above error. I hope it's just as simple as I imagine it to be, please tell me if I'm missing something.